### PR TITLE
Preparing Version 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# gnome-shell-extension-splash-indicator
+# Splash Indicator
 A simple and non-obstructive way to show currently launching applications.
+
+## How it all started
+I was not contended on gnomes startup notify implementation (the mouse pointer loading wheel wen launching apps). It disappears when pointer is not placed in proper locations (top bar or dock). Then I decided to try and implement some kind of third party splash screen for each apps but then it must be non-obstructive. Instead of a splash screen window I decided to turn it into a simple panel indicator.
+
+## Reminder
+- only apps with enable `startup-notify` works for this extension
+- apps with no symbolic icons or given the path will automatically fallback to a greyed out desktop icon.
+
+# Installation
+```bash
+$ git clone https://github.com/ochi12/gnome-shell-extension-splash-indicator.git
+$ make build
+$ make install
+```

--- a/splashindicator@ochi12.github.com/extension.js
+++ b/splashindicator@ochi12.github.com/extension.js
@@ -17,6 +17,8 @@
  */
 
 import GObject from 'gi://GObject';
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
 import St from 'gi://St';
 
 import {Extension, gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
@@ -25,15 +27,29 @@ import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
+import Shell from 'gi://Shell';
+import Clutter from 'gi://Clutter';
+
 const Indicator = GObject.registerClass(
 class Indicator extends PanelMenu.Button {
     _init() {
         super._init(0.0, _('My Shiny Indicator'));
 
-        this.add_child(new St.Icon({
-            icon_name: 'face-smile-symbolic',
+        this._icontheme = new St.IconTheme();
+
+        this._icon = new St.Icon({
             style_class: 'system-status-icon',
-        }));
+        });
+        this._label = new St.Label({
+            y_align: Clutter.ActorAlign.CENTER,
+        });
+
+        const box = new St.BoxLayout({vertical: false});
+        box.add_child(this._icon);
+        box.add_child(this._label);
+
+
+        this.add_child(box);
 
         let item = new PopupMenu.PopupMenuItem(_('Show Notification'));
         item.connect('activate', () => {
@@ -41,16 +57,87 @@ class Indicator extends PanelMenu.Button {
         });
         this.menu.addMenuItem(item);
     }
+
+    _setIcon(iconName) {
+        if (this._icontheme.has_icon(iconName)) {
+            this._icon.gicon = Gio.ThemedIcon.new(iconName);
+        } else {
+            // recover original path without the added "-symbolic"
+            const parts = iconName.split('-');
+            const finalIconName = parts.slice(0, -1).join('-');
+            console.log(`icon name: ${finalIconName}`);
+            this._icon.gicon = Gio.icon_new_for_string(finalIconName);
+        }
+    }
+
+    _setLabel(appName) {
+        this._label.set_text(appName);
+    }
+
+    fade_in(iconName, appName) {
+        this._setIcon(`${iconName}-symbolic`);
+        this._setLabel(`Launching ${appName}...`);
+
+        this.remove_all_transitions();
+        this.opacity = 0;
+        this.show();
+
+        this.ease({
+            opacity: 255,
+            duration: 100, // in ms
+            mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+            onComplete: () => {
+                this.show();
+            },
+        });
+    }
+
+    fade_out() {
+        this.remove_all_transitions();
+        this.ease({
+            opacity: 0,
+            duration: 350, // in ms
+            mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+            onComplete: () => {
+                this.hide();
+            },
+        });
+    }
 });
 
 export default class IndicatorExampleExtension extends Extension {
     enable() {
         this._indicator = new Indicator();
-        Main.panel.addToStatusArea(this.uuid, this._indicator);
+        Main.panel.addToStatusArea(this.uuid, this._indicator, -1, 'left');
+
+        this._fadeOutDelayId = null;
+
+        this._appMonitor = Shell.AppSystem.get_default();
+        this._appStateChangedId = this._appMonitor.connect('app-state-changed', (appSystem, object) => {
+            const appState = object.get_state();
+
+            if (appState ===  Shell.AppState.STARTING) {
+                console.log(`Openning App Named ${object.get_icon().to_string()}`);
+                const appName = object.get_name();
+                const iconName = object.get_icon().to_string();
+                this._indicator.fade_in(iconName, appName);
+                if (this._fadeOutDelayId != null) {
+                    GLib.source_remove(this._fadeOutDelayId);
+                    this._fadeOutDelayId = null;
+                }
+            } else {
+                this._fadeOutDelayId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500, () => {
+                    this._indicator.fade_out();
+                    return GLib.SOURCE_REMOVE;
+                });
+            }
+        });
     }
 
     disable() {
         this._indicator.destroy();
         this._indicator = null;
+        this._appMonitor.disconnect(this._appStateChangedId);
+        this._appMonitor = null;
     }
 }

--- a/splashindicator@ochi12.github.com/extension.js
+++ b/splashindicator@ochi12.github.com/extension.js
@@ -23,7 +23,6 @@ import St from 'gi://St';
 
 import {Extension, gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
-import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 

--- a/splashindicator@ochi12.github.com/extension.js
+++ b/splashindicator@ochi12.github.com/extension.js
@@ -54,12 +54,6 @@ class SplashIndicator extends PanelMenu.Button {
         box.add_child(this._icon);
         box.add_child(this._label);
         this.add_child(box);
-
-        let item = new PopupMenu.PopupMenuItem(_('Show Notification'));
-        item.connect('activate', () => {
-            Main.notify(_('Whatʼs up, folks?'));
-        });
-        this.menu.addMenuItem(item);
     }
 
     _setIcon(iconName) {

--- a/splashindicator@ochi12.github.com/metadata.json
+++ b/splashindicator@ochi12.github.com/metadata.json
@@ -2,7 +2,11 @@
   "name": "Splash Indicator",
   "description": "A simple and non-obstructive way to show currently launching applications",
   "uuid": "splashindicator@ochi12.github.com",
+  "version": 1,
+  "version-name": "1.0.0",
   "shell-version": [
-    "48"
-  ]
+    "45", "46", "47" ,"48"
+  ],
+  "gettext-domain": "example@gjs.guide",
+  "url": "https://github.com/ochi12/gnome-shell-extension-splash-indicator"
 }

--- a/splashindicator@ochi12.github.com/stylesheet.css
+++ b/splashindicator@ochi12.github.com/stylesheet.css
@@ -1,1 +1,0 @@
-/* Add your custom extension styling here */


### PR DESCRIPTION
# What's Working?
- splash indicator appears when launching an application
- current splash indicator is overwritten when another app is launched
- fade out transition when current app is running.

[Screencast From 2025-05-20 23-13-24.webm](https://github.com/user-attachments/assets/c3e9caa2-8163-4a3c-9634-8cd32052e898)


# What's Not Working Yet?
- if first app indicated by the splash is interrupted by a second app and the second app loads first the splash indicator for the first app doesn't resume.

[Screencast From 2025-05-20 23-14-27.webm](https://github.com/user-attachments/assets/3bc611e8-e2a0-4520-b830-005119f3bd24)

