### PR TITLE
Enhancement: use box layout instead of panel menu button for the indicator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 splashindicator@ochi12.github.com.zip
+splashindicator-dev@ochi12.github.com.zip


### PR DESCRIPTION
Currently indicator uses panel menu button which is not optimal and unnecessary. 

closes https://github.com/ochi12/gnome-shell-extension-splash-indicator/issues/3